### PR TITLE
Add first bazel rules and BUILD.

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -21,8 +21,8 @@ jobs:
         arch:
           - 'x86_64'
         compiler:
-          - 'ldc-latest'
-          - 'dmd-latest'
+          - 'ldc2'
+          - 'dmd'
 
     steps:
       - name: Cache bazel
@@ -37,12 +37,10 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - name: Test LDC2
-        if: startsWith(matrix.compiler,'ldc')
-        run: bazel test  --test_output=all --test_verbose_timeout_warnings $(bazel query //...) --//rules:d_compiler=ldc2 
-
-      - name: Test DMD
+      - name: Test
         # TODO(klknn): Fix dmd+macos linker errors:
         # https://github.com/klknn/kdr/actions/runs/3382812329/jobs/5618111876
-        if: startsWith(matrix.compiler,'dmd') && startsWith(matrix.os,'macos') != true
-        run: bazel test  --test_output=all --test_verbose_timeout_warnings $(bazel query //...) --//rules:d_compiler=dmd
+        if: (startsWith(matrix.compiler,'dmd') && startsWith(matrix.os,'macos')) != true
+        run: |
+          bazel test  --test_output=all --test_verbose_timeout_warnings \
+            $(bazel query //...) --//rules:d_compiler=${{ matrix.compiler }}

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,0 +1,42 @@
+name: bazel
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          # TODO(klknn): Support Windows cache
+          # https://qiita.com/homulerdora/items/12745a02a2663bc956fd#%E8%A7%A3%E6%B1%BA%E7%AD%96
+          # - windows-latest
+        arch:
+          - 'x86_64'
+        compiler:
+          - 'ldc-latest'
+          - 'dmd-latest'
+
+    steps:
+      - name: Cache bazel
+        uses: actions/cache@v3
+        env:
+          cache-name: bazel-cache
+        with:
+          path: |
+            ~/.cache/bazelisk
+            ~/.cache/bazel
+          key: ${{ matrix.os }}-${{ matrix.compiler }}-${{ env.cache-name }}
+
+      - uses: actions/checkout@v3
+
+      - name: Test LDC2
+        if: startsWith(matrix.compiler,'ldc')
+        run: bazel test  --test_output=all $(bazel query //...) --//rules:d_compiler=ldc2
+
+      - name: Test DMD
+        if: startsWith(matrix.compiler,'dmd')
+        run: bazel test  --test_output=all $(bazel query //...) --//rules:d_compiler=dmd

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,6 +1,10 @@
 name: bazel
 
-on: [push, pull_request]
+on:
+  push:
+  # Nightly builds
+  schedule:
+    - cron: '00 00 * * *'
 
 jobs:
   test:
@@ -35,8 +39,10 @@ jobs:
 
       - name: Test LDC2
         if: startsWith(matrix.compiler,'ldc')
-        run: bazel test  --test_output=all $(bazel query //...) --//rules:d_compiler=ldc2
+        run: bazel test  --test_output=all --test_verbose_timeout_warnings $(bazel query //...) --//rules:d_compiler=ldc2 
 
       - name: Test DMD
-        if: startsWith(matrix.compiler,'dmd')
-        run: bazel test  --test_output=all $(bazel query //...) --//rules:d_compiler=dmd
+        # TODO(klknn): Fix dmd+macos linker errors:
+        # https://github.com/klknn/kdr/actions/runs/3382812329/jobs/5618111876
+        if: startsWith(matrix.compiler,'dmd') && startsWith(matrix.os,'macos') != true
+        run: bazel test  --test_output=all --test_verbose_timeout_warnings $(bazel query //...) --//rules:d_compiler=dmd

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *
+.*
+builds/
 
 !*/
 !*.d
@@ -25,6 +27,3 @@
 !.github/
 !.github/workflows/
 !.github/workflows/*.yml
-
-.*
-builds/

--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,15 @@
 !*.json
 !*.md
 !*.py
+!*.bzl
+!BUILD
+!WORKSPACE
 !.gitignore
 !LICENSE
 
 !source/
 !bin/
+!rules/
 
 !resource/
 !resource/*.ver

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,6 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//rules:dmd.bzl", "dmd_repositories")
+load("//rules:ldc2.bzl", "ldc2_repositories")
+
+dmd_repositories()
+ldc2_repositories()

--- a/rules/BUILD
+++ b/rules/BUILD
@@ -1,0 +1,102 @@
+"""Bazel rules.
+
+Flags:
+
+  To switch D compiler, set: --//rules:d_compiler=ldc2 (default: dmd)
+"""
+package(default_visibility = ["//visibility:public"])
+load(":d_toolchain.bzl", "d_compiler")
+
+d_compiler(name = "d_compiler", build_setting_default = "dmd")
+
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+)
+
+config_setting(
+    name = "darwin",
+    values = {"host_cpu": "darwin"},
+)
+
+config_setting(
+    name = "k8",
+    values = {"host_cpu": "k8"},
+)
+
+config_setting(
+    name = "x64_windows",
+    values = {"host_cpu": "x64_windows"},
+)
+
+filegroup(
+    name = "dmd",
+    srcs = select({
+        ":darwin": ["@dmd_darwin_x86_64//:dmd"],
+        ":k8": ["@dmd_linux_x86_64//:dmd"],
+        ":x64_windows": ["@dmd_windows_x86_64//:dmd"],
+    }),
+)
+
+filegroup(
+    name = "libphobos2",
+    srcs = select({
+        ":darwin": ["@dmd_darwin_x86_64//:libphobos2"],
+        ":k8": ["@dmd_linux_x86_64//:libphobos2"],
+        ":x64_windows": ["@dmd_windows_x86_64//:libphobos2"],
+    }),
+)
+
+filegroup(
+    name = "phobos-src",
+    srcs = select({
+        ":darwin": ["@dmd_darwin_x86_64//:phobos-src"],
+        ":k8": ["@dmd_linux_x86_64//:phobos-src"],
+        ":x64_windows": ["@dmd_windows_x86_64//:phobos-src"],
+    }),
+)
+
+filegroup(
+    name = "druntime-import-src",
+    srcs = select({
+        ":darwin": ["@dmd_darwin_x86_64//:druntime-import-src"],
+        ":k8": ["@dmd_linux_x86_64//:druntime-import-src"],
+        ":x64_windows": ["@dmd_windows_x86_64//:druntime-import-src"],
+    }),
+)
+
+filegroup(
+    name = "ldc2",
+    srcs = select({
+        ":darwin": ["@ldc2_darwin_x86_64//:ldc2"],
+        ":k8": ["@ldc2_linux_x86_64//:ldc2"],
+        ":x64_windows": ["@ldc2_windows_x86_64//:ldc2"],
+    }),
+)
+
+filegroup(
+    name = "libphobos2-ldc2",
+    srcs = select({
+        ":darwin": ["@ldc2_darwin_x86_64//:libphobos2"],
+        ":k8": ["@ldc2_linux_x86_64//:libphobos2"],
+        ":x64_windows": ["@ldc2_windows_x86_64//:libphobos2"],
+    }),
+)
+
+filegroup(
+    name = "phobos-src-ldc2",
+    srcs = select({
+        ":darwin": ["@ldc2_darwin_x86_64//:phobos-src"],
+        ":k8": ["@ldc2_linux_x86_64//:phobos-src"],
+        ":x64_windows": ["@ldc2_windows_x86_64//:phobos-src"],
+    }),
+)
+
+filegroup(
+    name = "druntime-import-src-ldc2",
+    srcs = select({
+        ":darwin": ["@ldc2_darwin_x86_64//:druntime-import-src"],
+        ":k8": ["@ldc2_linux_x86_64//:druntime-import-src"],
+        ":x64_windows": ["@ldc2_windows_x86_64//:druntime-import-src"],
+    }),
+)

--- a/rules/d.bzl
+++ b/rules/d.bzl
@@ -1,0 +1,398 @@
+# Copyright 2022 klknn.
+# Copyright 2015 The Bazel Authors. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""D rules for Bazel."""
+load(":d_toolchain.bzl", "d_toolchain", "d_toolchain_attrs")
+
+COMPILATION_MODE_FLAGS_POSIX = {
+    "fastbuild": ["-g"],
+    "dbg": ["-debug", "-g"],
+    "opt": ["-checkaction=halt", "-boundscheck=safeonly", "-O"],
+}
+
+COMPILATION_MODE_FLAGS_WINDOWS = {
+    "fastbuild": ["-g", "-m64", "-mscrtlib=msvcrt"],
+    "dbg": ["-debug", "-g", "-m64", "-mscrtlib=msvcrtd"],
+    "opt": ["-checkaction=halt", "-boundscheck=safeonly", "-O",
+        "-m64", "-mscrtlib=msvcrt"],
+}
+
+def _is_windows(ctx):
+    return ctx.configuration.host_path_separator == ";"
+
+def _compilation_mode_flags(ctx):
+    """Returns a list of flags based on the compilation_mode."""
+    if _is_windows(ctx):
+        return COMPILATION_MODE_FLAGS_WINDOWS[ctx.var["COMPILATION_MODE"]]
+    else:
+        return COMPILATION_MODE_FLAGS_POSIX[ctx.var["COMPILATION_MODE"]]
+
+def _format_version(name):
+    """Formats the string name to be used in a --version flag."""
+    return name.replace("-", "_")
+
+def _build_import(label, im):
+    """Builds the import path under a specific label"""
+    import_path = ""
+    if label.workspace_root:
+        import_path += label.workspace_root + "/"
+    if label.package:
+        import_path += label.package + "/"
+    import_path += im
+    return import_path
+
+def _files_directory(files):
+    """Returns the shortest parent directory of a list of files."""
+    dir = files[0].dirname
+    for f in files:
+        if len(dir) > len(f.dirname):
+            dir = f.dirname
+    return dir
+
+def _build_compile_arglist(ctx, out, depinfo, extra_flags = []):
+    """Returns a list of strings constituting the D compile command arguments."""
+    toolchain = d_toolchain(ctx)
+    return (
+        _compilation_mode_flags(ctx) +
+        extra_flags + [
+            "-of" + out.path,
+            "-I.",
+            "-w",
+        ] +
+        ["-I%s" % _build_import(ctx.label, im) for im in ctx.attr.imports] +
+        ["-I%s" % im for im in depinfo.imports] +
+        ["-I" + _files_directory(toolchain.stdlib_src),
+         "-I" + _files_directory(toolchain.runtime_import_src)] +
+        ["%s=Have_%s" % (toolchain.flag_version, _format_version(ctx.label.name))] +
+        ["%s=%s" % (toolchain.flag_version, v) for v in ctx.attr.versions] +
+        ["%s=%s" % (toolchain.flag_version, v) for v in depinfo.versions]
+    )
+
+def _build_link_arglist(ctx, objs, out, depinfo):
+    """Returns a list of strings constituting the D link command arguments."""
+    toolchain = d_toolchain(ctx)
+    return (
+        _compilation_mode_flags(ctx) +
+        ["-of" + out.path] +
+        [("-L/LIBPATH:" if _is_windows(ctx) else "-L-L") + toolchain.stdlib[0].dirname] +
+        [f.path for f in depset(transitive = [depinfo.libs, depinfo.transitive_libs]).to_list()] +
+        depinfo.link_flags +
+        objs
+    )
+
+def _a_filetype(ctx, files):
+    lib_suffix = ".lib" if _is_windows(ctx) else ".a"
+    return [f for f in files if f.basename.endswith(lib_suffix)]
+
+def _setup_deps(ctx, deps, name, working_dir):
+    """Sets up dependencies.
+
+    Walks through dependencies and constructs the commands and flags needed
+    for linking the necessary dependencies.
+
+    Args:
+      deps: List of deps labels from ctx.attr.deps.
+      name: Name of the current target.
+      working_dir: The output directory of the current target's output.
+
+    Returns:
+      Returns a struct containing the following fields:
+        libs: List of Files containing the target's direct library dependencies.
+        transitive_libs: List of Files containing all of the target's
+            transitive libraries.
+        d_srcs: List of Files representing D source files of dependencies that
+            will be used as inputs for this target.
+        versions: List of D versions to be used for compiling the target.
+        imports: List of Strings containing input paths that will be passed
+            to the D compiler via -I flags.
+        link_flags: List of linker flags.
+    """
+
+    libs = []
+    transitive_libs = []
+    d_srcs = []
+    transitive_d_srcs = []
+    versions = []
+    imports = []
+    link_flags = []
+    for dep in deps:
+        if hasattr(dep, "d_lib"):
+            # The dependency is a d_library.
+            libs.append(dep.d_lib)
+            transitive_libs.append(dep.transitive_libs)
+            d_srcs += dep.d_srcs
+            transitive_d_srcs.append(dep.transitive_d_srcs)
+            versions += dep.versions + ["Have_%s" % _format_version(dep.label.name)]
+            link_flags.extend(dep.link_flags)
+            imports += [_build_import(dep.label, im) for im in dep.imports]
+
+        elif hasattr(dep, "d_srcs"):
+            # The dependency is a d_source_library.
+            d_srcs += dep.d_srcs
+            transitive_d_srcs.append(dep.transitive_d_srcs)
+            transitive_libs.append(dep.transitive_libs)
+            link_flags += ["-L%s" % linkopt for linkopt in dep.linkopts]
+            imports += [_build_import(dep.label, im) for im in dep.imports]
+            versions += dep.versions
+
+        elif CcInfo in dep:
+            # The dependency is a cc_library
+            native_libs = _a_filetype(ctx, _get_libs_for_static_executable(dep))
+            libs.extend(native_libs)
+            transitive_libs.append(depset(native_libs))
+
+        else:
+            fail("D targets can only depend on d_library, d_source_library, or " +
+                 "cc_library targets.", "deps")
+
+    return struct(
+        libs = depset(libs),
+        transitive_libs = depset(transitive = transitive_libs),
+        d_srcs = depset(d_srcs).to_list(),
+        transitive_d_srcs = depset(transitive = transitive_d_srcs),
+        versions = versions,
+        imports = depset(imports).to_list(),
+        link_flags = depset(link_flags).to_list(),
+    )
+
+def _d_library_impl(ctx):
+    """Implementation of the d_library rule."""
+    d_lib = ctx.actions.declare_file((ctx.label.name + ".lib") if _is_windows(ctx) else ("lib" + ctx.label.name + ".a"))
+
+    # Dependencies
+    depinfo = _setup_deps(ctx, ctx.attr.deps, ctx.label.name, d_lib.dirname)
+
+    # Build compile command.
+    compile_args = _build_compile_arglist(
+        ctx = ctx,
+        out = d_lib,
+        depinfo = depinfo,
+        extra_flags = ["-lib"],
+    )
+
+    # Convert sources to args
+    # This is done to support receiving a File that is a directory, as
+    # args will auto-expand this to the contained files
+    args = ctx.actions.args()
+    args.add_all(compile_args)
+    args.add_all(ctx.files.srcs)
+
+    toolchain = d_toolchain(ctx)
+    compile_inputs = depset(
+        ctx.files.srcs +
+        depinfo.d_srcs +
+        toolchain.stdlib +
+        toolchain.stdlib_src +
+        toolchain.runtime_import_src,
+        transitive = [
+            depinfo.transitive_d_srcs,
+            depinfo.libs,
+            depinfo.transitive_libs,
+        ],
+    )
+
+    ctx.actions.run(
+        inputs = compile_inputs,
+        tools = [toolchain.compiler],
+        outputs = [d_lib],
+        mnemonic = "Dcompile",
+        executable = toolchain.compiler.path,
+        arguments = [args],
+        use_default_shell_env = True,
+        progress_message = "Compiling D library " + ctx.label.name,
+    )
+
+    return struct(
+        files = depset([d_lib]),
+        d_srcs = ctx.files.srcs,
+        transitive_d_srcs = depset(depinfo.d_srcs),
+        transitive_libs = depset(transitive = [depinfo.libs, depinfo.transitive_libs]),
+        link_flags = depinfo.link_flags,
+        versions = ctx.attr.versions,
+        imports = ctx.attr.imports,
+        d_lib = d_lib,
+    )
+
+def _d_binary_impl_common(ctx, extra_flags = []):
+    """Common implementation for rules that build a D binary."""
+    d_bin = ctx.actions.declare_file(ctx.label.name + ".exe" if _is_windows(ctx) else ctx.label.name)
+    d_obj = ctx.actions.declare_file(ctx.label.name + (".obj" if _is_windows(ctx) else ".o"))
+    depinfo = _setup_deps(ctx, ctx.attr.deps, ctx.label.name, d_bin.dirname)
+
+    # Build compile command
+    compile_args = _build_compile_arglist(
+        ctx = ctx,
+        depinfo = depinfo,
+        out = d_obj,
+        extra_flags = ["-c"] + extra_flags,
+    )
+
+    # Convert sources to args
+    # This is done to support receiving a File that is a directory, as
+    # args will auto-expand this to the contained files
+    args = ctx.actions.args()
+    args.add_all(compile_args)
+    args.add_all(ctx.files.srcs)
+
+    toolchain = d_toolchain(ctx)
+    toolchain_files = (
+        toolchain.stdlib +
+        toolchain.stdlib_src +
+        toolchain.runtime_import_src
+    )
+
+    compile_inputs = depset(
+        ctx.files.srcs + depinfo.d_srcs + toolchain_files,
+        transitive = [depinfo.transitive_d_srcs],
+    )
+    ctx.actions.run(
+        inputs = compile_inputs,
+        tools = [toolchain.compiler],
+        outputs = [d_obj],
+        mnemonic = "Dcompile",
+        executable = toolchain.compiler.path,
+        arguments = [args],
+        use_default_shell_env = True,
+        progress_message = "Compiling D binary " + ctx.label.name,
+    )
+
+    # Build link command
+    link_args = _build_link_arglist(
+        ctx = ctx,
+        objs = [d_obj.path],
+        depinfo = depinfo,
+        out = d_bin,
+    )
+
+    link_inputs = depset(
+        [d_obj] + toolchain_files,
+        transitive = [depinfo.libs, depinfo.transitive_libs],
+    )
+
+    ctx.actions.run(
+        inputs = link_inputs,
+        tools = [toolchain.compiler],
+        outputs = [d_bin],
+        mnemonic = "Dlink",
+        executable = toolchain.compiler.path,
+        arguments = link_args,
+        use_default_shell_env = True,
+        progress_message = "Linking D binary " + ctx.label.name,
+    )
+
+    return struct(
+        d_srcs = ctx.files.srcs,
+        transitive_d_srcs = depset(depinfo.d_srcs),
+        imports = ctx.attr.imports,
+        executable = d_bin,
+    )
+
+def _d_binary_impl(ctx):
+    """Implementation of the d_binary rule."""
+    return _d_binary_impl_common(ctx)
+
+def _d_test_impl(ctx):
+    """Implementation of the d_test rule."""
+    return _d_binary_impl_common(ctx, extra_flags = ["-unittest", "-main"])
+
+def _get_libs_for_static_executable(dep):
+    """
+    Finds the libraries used for linking an executable statically.
+    This replaces the old API dep.cc.libs
+    Args:
+      dep: Target
+    Returns:
+      A list of File instances, these are the libraries used for linking.
+    """
+    libs = []
+    for li in dep[CcInfo].linking_context.linker_inputs.to_list():
+        for library_to_link in li.libraries:
+            if library_to_link.static_library != None:
+                libs.append(library_to_link.static_library)
+            elif library_to_link.pic_static_library != None:
+                libs.append(library_to_link.pic_static_library)
+            elif library_to_link.interface_library != None:
+                libs.append(library_to_link.interface_library)
+            elif library_to_link.dynamic_library != None:
+                libs.append(library_to_link.dynamic_library)
+    return libs
+
+def _d_source_library_impl(ctx):
+    """Implementation of the d_source_library rule."""
+    transitive_d_srcs = []
+    transitive_libs = []
+    transitive_transitive_libs = []
+    transitive_imports = depset()
+    transitive_linkopts = depset()
+    transitive_versions = depset()
+    for dep in ctx.attr.deps:
+        if hasattr(dep, "d_srcs"):
+            # Dependency is another d_source_library target.
+            transitive_d_srcs.append(dep.d_srcs)
+            transitive_imports = depset(dep.imports, transitive = [transitive_imports])
+            transitive_linkopts = depset(dep.linkopts, transitive = [transitive_linkopts])
+            transitive_versions = depset(dep.versions, transitive = [transitive_versions])
+            transitive_transitive_libs.append(dep.transitive_libs)
+
+        elif CcInfo in dep:
+            # Dependency is a cc_library target.
+            native_libs = _a_filetype(ctx, _get_libs_for_static_executable(dep))
+            transitive_libs.extend(native_libs)
+
+        else:
+            fail("d_source_library can only depend on other " +
+                 "d_source_library or cc_library targets.", "deps")
+
+    return struct(
+        d_srcs = ctx.files.srcs,
+        transitive_d_srcs = depset(transitive = transitive_d_srcs, order = "postorder"),
+        transitive_libs = depset(transitive_libs, transitive = transitive_transitive_libs),
+        imports = ctx.attr.imports + transitive_imports.to_list(),
+        linkopts = ctx.attr.linkopts + transitive_linkopts.to_list(),
+        versions = ctx.attr.versions + transitive_versions.to_list(),
+    )
+
+_d_public_attrs = {
+    "srcs": attr.label_list(allow_files = [".d", ".di"]),
+    "imports": attr.string_list(),
+    "linkopts": attr.string_list(),
+    "versions": attr.string_list(),
+    "deps": attr.label_list(),
+}
+
+_d_common_attrs = dict(_d_public_attrs.items() + d_toolchain_attrs.items())
+
+d_library = rule(
+    _d_library_impl,
+    attrs = _d_common_attrs,
+)
+
+d_source_library = rule(
+    _d_source_library_impl,
+    attrs = _d_common_attrs,
+)
+
+d_binary = rule(
+    _d_binary_impl,
+    attrs = _d_common_attrs,
+    executable = True,
+)
+
+d_test = rule(
+    _d_test_impl,
+    attrs = _d_common_attrs,
+    executable = True,
+    test = True,
+)

--- a/rules/d.bzl
+++ b/rules/d.bzl
@@ -305,7 +305,8 @@ def _d_binary_impl(ctx):
 
 def _d_test_impl(ctx):
     """Implementation of the d_test rule."""
-    return _d_binary_impl_common(ctx, extra_flags = ["-unittest", "-main"])
+    # TODO(klknn): Find cov files.
+    return _d_binary_impl_common(ctx, extra_flags = ["-unittest", "-cov", "-main"])
 
 def _get_libs_for_static_executable(dep):
     """

--- a/rules/d_toolchain.bzl
+++ b/rules/d_toolchain.bzl
@@ -1,0 +1,55 @@
+"""D toolchain module unifying compilers e.g. DMD, LDC2. """
+
+load(":dmd.bzl", "dmd_compile_attrs")
+load(":ldc2.bzl", "ldc2_compile_attrs")
+
+_DCompilerInfo = provider(fields = ["name"])
+
+def _d_compiler_impl(ctx):
+    return _DCompilerInfo(name = ctx.build_setting_value)
+
+d_compiler = rule(
+    _d_compiler_impl,
+    build_setting = config.string(flag = True)
+)
+
+def d_toolchain(ctx):
+    """Returns a struct containing info about the D toolchain.
+
+    Args:
+      ctx: The ctx object.
+
+    Return:
+      Struct containing D toolchain info:
+    """
+    name = ctx.attr.d_compiler[_DCompilerInfo].name
+    # print("D compiler selected by --//rules:d_compiler is: " + name)
+    if name == "dmd":
+        flag_version = ctx.attr._dmd_flag_version
+        compiler = ctx.file._dmd_compiler
+        runtime_import_src = ctx.files._dmd_runtime_import_src
+        stdlib = ctx.files._dmd_stdlib
+        stdlib_src = ctx.files._dmd_stdlib_src
+    elif name == "ldc2":
+        flag_version = ctx.attr._ldc2_flag_version
+        compiler = ctx.file._ldc2_compiler
+        runtime_import_src = ctx.files._ldc2_runtime_import_src
+        stdlib = ctx.files._ldc2_stdlib
+        stdlib_src = ctx.files._ldc2_stdlib_src
+    else:
+        # TODO(klknn): Support GDC.
+        fail("unknown compiler: " + name)
+
+    return struct(
+        flag_version = flag_version,
+        compiler = compiler,
+        runtime_import_src = runtime_import_src,
+        stdlib = stdlib,
+        stdlib_src = stdlib_src,
+    )
+
+d_toolchain_attrs = dict(
+    {"d_compiler": attr.label(default = ":d_compiler")}.items() +
+    dmd_compile_attrs.items() +
+    ldc2_compile_attrs.items()
+)

--- a/rules/dmd.bzl
+++ b/rules/dmd.bzl
@@ -1,0 +1,103 @@
+"""DMD rules."""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+DMD_BUILD_FILE = """
+package(default_visibility = ["//visibility:public"])
+
+config_setting(
+    name = "darwin",
+    values = {"host_cpu": "darwin"},
+)
+
+config_setting(
+    name = "k8",
+    values = {"host_cpu": "k8"},
+)
+
+config_setting(
+    name = "x64_windows",
+    values = {"host_cpu": "x64_windows"},
+)
+
+filegroup(
+    name = "dmd",
+    srcs = select({
+        ":darwin": ["dmd2/osx/bin/dmd"],
+        ":k8": ["dmd2/linux/bin64/dmd"],
+        ":x64_windows": ["dmd2/windows/bin64/dmd.exe"],
+    }),
+)
+
+filegroup(
+    name = "libphobos2",
+    srcs = select({
+        ":darwin": ["dmd2/osx/lib/libphobos2.a"],
+        ":k8": [
+            "dmd2/linux/lib64/libphobos2.a",
+            "dmd2/linux/lib64/libphobos2.so",
+        ],
+        ":x64_windows": ["dmd2/windows/lib64/phobos64.lib"],
+    }),
+)
+
+filegroup(
+    name = "phobos-src",
+    srcs = glob(["dmd2/src/phobos/**/*.*"]),
+)
+
+filegroup(
+    name = "druntime-import-src",
+    srcs = glob([
+        "dmd2/src/druntime/import/*.*",
+        "dmd2/src/druntime/import/**/*.*",
+    ]),
+)
+"""
+
+def dmd_repositories():
+    http_archive(
+        name = "dmd_linux_x86_64",
+        urls = [
+            "http://downloads.dlang.org/releases/2021/dmd.2.097.1.linux.tar.xz",
+        ],
+        sha256 = "030fd1bc3b7308dadcf08edc1529d4a2e46496d97ee92ed532b246a0f55745e6",
+        build_file_content = DMD_BUILD_FILE,
+    )
+
+    http_archive(
+        name = "dmd_darwin_x86_64",
+        urls = [
+            "http://downloads.dlang.org/releases/2021/dmd.2.097.1.osx.tar.xz",
+        ],
+        sha256 = "383a5524266417bcdd3126da947be7caebd4730f789021e9ec26d869c8448f6a",
+        build_file_content = DMD_BUILD_FILE,
+    )
+
+    http_archive(
+        name = "dmd_windows_x86_64",
+        urls = [
+            "http://downloads.dlang.org/releases/2021/dmd.2.097.1.windows.zip",
+        ],
+        sha256 = "63a00e624bf23ab676c543890a93b5325d6ef6b336dee2a2f739f2bbcef7ef1f",
+        build_file_content = DMD_BUILD_FILE,
+    )
+
+dmd_compile_attrs = {
+    "_dmd_flag_version": attr.string(default = "-version"),
+    "_dmd_compiler": attr.label(
+        default = Label("//rules:dmd"),
+        executable = True,
+        allow_single_file = True,
+        cfg = "host",
+    ),
+    "_dmd_runtime_import_src": attr.label(
+        default = Label("//rules:druntime-import-src"),
+    ),
+    "_dmd_stdlib": attr.label(
+        default = Label("//rules:libphobos2"),
+    ),
+    "_dmd_stdlib_src": attr.label(
+        default = Label("//rules:phobos-src"),
+    ),
+}

--- a/rules/ldc2.bzl
+++ b/rules/ldc2.bzl
@@ -1,0 +1,116 @@
+"""LDC2 rules for Bazel."""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def ldc2_sha256dict(s):
+    d = {}
+    for line in s.strip().splitlines():
+        v, k = line.split("  ")
+        d[k] = v
+    return d
+
+# https://github.com/ldc-developers/ldc/releases/download/v1.28.0/ldc2-1.28.0.sha256sums.txt
+_LDC2_SHA256SUMS = ldc2_sha256dict("""
+17fee8bb535bcb8cda0a45947526555c46c045f302a7349cc8711b254e54cf09  ldc-1.28.0-src.tar.gz
+f59936c1c816698ab790b13b4a8cd0b2954bc5f43a38e4dd7ffaa29e28c2f3a6  ldc-1.28.0-src.zip
+52666ebeaeddee402c022cbcdc39b8c27045e6faab15e53c72564b9eaf32ccff  ldc2-1.28.0-android-aarch64.tar.xz
+c9b22ea84ed5738afcdf1740f501eea68a3269bda7e1a9eb1f139f9c4e5b96de  ldc2-1.28.0-android-armv7a.tar.xz
+9786c36c4dfd29dd308a50c499c115e4c2079baeaded07e5ac5396c4a7fd0278  ldc2-1.28.0-linux-x86_64.tar.xz
+f9786b8c28d8af1fdd331d8eb889add80285dbebfb97ea47d5dd9110a7df074b  ldc2-1.28.0-osx-arm64.tar.xz
+02472507de988c8b5dd83b189c6df3b474741546589496c2ff3d673f26b8d09a  ldc2-1.28.0-osx-x86_64.tar.xz
+8917876e2dbe763feec2d2d2ba81f20bfd32ed13753e5ea1bc5ce0ea564f3eaf  ldc2-1.28.0-windows-multilib.7z
+e6ce44b6533fc4b7639b6ed078bdb107294fefc7b638141c42bf37b46e491990  ldc2-1.28.0-windows-multilib.exe
+26bb3ece7774ef70d9c7485eab5fbc182d4e74411e4a8d2f339e9b421a76f069  ldc2-1.28.0-windows-x64.7z
+af5465b316dfb582ded4fd6f83dfa02dfdd896fad6d397cc53d098e3ba9f9281  ldc2-1.28.0-windows-x86.7z
+""")
+
+_LDC2_BUILD_FILE = """
+package(default_visibility = ["//visibility:public"])
+
+config_setting(
+    name = "darwin",
+    values = {"host_cpu": "darwin"},
+)
+
+config_setting(
+    name = "k8",
+    values = {"host_cpu": "k8"},
+)
+
+config_setting(
+    name = "x64_windows",
+    values = {"host_cpu": "x64_windows"},
+)
+
+filegroup(
+    name = "ldc2",
+    srcs = ["bin/ldc2"],
+)
+
+filegroup(
+    name = "libphobos2",
+    srcs = select({
+        ":darwin": ["lib/libphobos2-ldc.a", "lib/libphobos2-ldc-shared.dylib"],
+        ":k8": ["lib/libphobos2-ldc.a", "lib/libphobos2-ldc-shared.so"],
+        ":x64_windows": ["lib/phobos2-ldc.lib"],
+    }),
+)
+
+filegroup(
+    name = "phobos-src",
+    srcs = glob([
+        "import/std/*.*",
+        "import/std/**/*.*",
+    ]),
+)
+
+filegroup(
+    name = "druntime-import-src",
+    srcs = glob([
+        "import/*.*",
+        "import/core/*.*",
+        "import/core/**/*.*",
+        "import/etc/*.*",
+        "import/etc/**/*.*",
+        "import/ldc/*.*",
+        "import/ldc/**/*.*",
+    ]),
+)
+"""
+
+def ldc2_archive(version, os, kernel, arch, ext):
+    name = "ldc2_" + kernel + "_" + arch
+    prefix = "ldc2-" + version + "-" + os + "-" + arch
+    tarxz = prefix + ext
+    return http_archive(
+        name = name,
+        urls = ["https://github.com/ldc-developers/ldc/releases/download/v" + version + "/" + tarxz],
+        sha256 = _LDC2_SHA256SUMS[tarxz],
+        strip_prefix=prefix,
+        build_file_content = _LDC2_BUILD_FILE,
+    )
+
+def ldc2_repositories(version="1.28.0"):
+    # TODO(karita): Support non x86_64 arch
+    ldc2_archive(version, "linux", "linux", "x86_64", ".tar.xz")
+    ldc2_archive(version, "osx", "darwin", "x86_64", ".tar.xz")
+    ldc2_archive(version, "windows", "windows", "x64", ".7z")
+
+ldc2_compile_attrs = {
+    "_ldc2_flag_version": attr.string(default = "--d-version"),
+    "_ldc2_compiler": attr.label(
+        default = Label("//rules:ldc2"),
+        executable = True,
+        allow_single_file = True,
+        cfg = "host",
+    ),
+    "_ldc2_runtime_import_src": attr.label(
+        default = Label("//rules:druntime-import-src-ldc2"),
+    ),
+    "_ldc2_stdlib": attr.label(
+        default = Label("//rules:libphobos2-ldc2"),
+    ),
+    "_ldc2_stdlib_src": attr.label(
+        default = Label("//rules:phobos-src-ldc2"),
+    ),
+}

--- a/source/kdr/BUILD
+++ b/source/kdr/BUILD
@@ -10,5 +10,5 @@ d_library(
 d_test(
     name = "random_test",
     srcs = ["random.d"],
-    deps = [":random"],
+    size = "small",
 )

--- a/source/kdr/BUILD
+++ b/source/kdr/BUILD
@@ -1,0 +1,14 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//rules:d.bzl", "d_library", "d_test")
+
+d_library(
+    name = "random",
+    srcs = ["random.d"],
+)
+
+d_test(
+    name = "random_test",
+    srcs = ["random.d"],
+    deps = [":random"],
+)


### PR DESCRIPTION
Related to #9

Forked https://github.com/bazelbuild/rules_d to support LDC2 compiler which can be enabled by `bazel build ... --//rules:d_compiler=ldc2`