### PR TITLE
Add kdr.logging.

### DIFF
--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,8 +1,8 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"dplug": "13.0.3",
-		"intel-intrinsics": "1.10.8",
-		"mir-core": "1.3.14"
+		"dplug": "13.3.0",
+		"intel-intrinsics": "1.10.10",
+		"mir-core": "1.3.15"
 	}
 }

--- a/source/kdr/BUILD
+++ b/source/kdr/BUILD
@@ -127,3 +127,12 @@ d_library_with_test(
         "@Dplug//:core",
     ],
 )
+
+d_library_with_test(
+    name = "logging",
+    srcs = ["logging.d"],
+    imports = [".."],
+    deps = [
+        "@Dplug//:core",
+    ],
+)

--- a/source/kdr/logging.d
+++ b/source/kdr/logging.d
@@ -1,0 +1,90 @@
+// -*- mode: d; c-basic-offset: 2 -*-
+module kdr.logging;
+
+import core.thread.types : ThreadID;
+import core.stdc.stdio : fprintf, fputc, stderr;
+import core.stdc.time : tm;
+import std.datetime.systime : Clock, SysTime;
+
+import dplug.core.nogc : assumeNothrowNoGC;
+import dplug.core.sync : UncheckedMutex;
+
+private ThreadID _thisThreadID() @trusted @nogc nothrow {
+  version (Windows) {
+    import core.sys.windows.winbase;
+    return GetCurrentThreadId();
+  }
+  version (Posix) {
+    import core.sys.posix.pthread : pthread_self;
+    return pthread_self();
+  }
+}
+
+private __gshared UncheckedMutex outMutex;
+
+/// Logging time info with usecs.
+struct LogTime {
+  /// Time info except usecs.
+  tm t;
+  /// Micro seconds.
+  long usec;
+
+  alias t this;
+}
+
+private LogTime currentTime() {
+  // TODO(klknn): Make this @nogc and nothrow.
+  const SysTime st = Clock.currTime;
+  return LogTime(
+      st.toTM(),
+      st.fracSecs().total!"usecs" % 1_000_000);
+}
+
+/// Emits log at info level.
+/// Params:
+///   fmt = C-style format string.
+///   args = arguments to be formatted.
+///   line = line number where this log is created.
+///   f = file name where this log is created.
+nothrow @nogc
+void logInfo(int line = __LINE__, string f = __FILE__, Args ...)(const(char)* fmt, Args args) {
+  LogTime t = assumeNothrowNoGC(&currentTime)();
+
+  // TODO(klknn): Support any buffer outputs in addition to stderr.
+  outMutex.lockLazy();
+  scope (exit) outMutex.unlock();
+
+  // Based on abseil-py format.
+  // https://github.com/abseil/abseil-py/blob/9954557f9df0b346a57ff82688438c55202d2188/absl/logging/__init__.py#L731
+  fprintf(
+      stderr,
+      "%c%02d%02d %02d:%02d:%02d.%06ld %5lu %s:%d] ",
+      'I',
+      t.tm_mon + 1, t.tm_mday,
+      t.tm_hour,
+      t.tm_min,
+      t.tm_sec,
+      t.usec, // TODO(klknn): time.millitm,
+      _thisThreadID,
+      f.ptr,
+      line);
+  fprintf(stderr, fmt, args);
+  fputc('\n', stderr);
+}
+
+unittest {
+  import core.thread;
+  import core.time;
+
+  auto other = new Thread({
+      foreach (i; 0 .. 3) {
+        logInfo("%d-th log from other thread %lu.", i, _thisThreadID);
+        Thread.sleep(dur!"msecs"(100));
+      }
+    }).start();
+  foreach (i; 0 .. 3) {
+    logInfo("%d-th log from this thread %lu.", i, _thisThreadID);
+    Thread.sleep(dur!"msecs"(100));
+  }
+  other.join();
+}


### PR DESCRIPTION
Unlike [std.logger](https://dlang.org/phobos/std_logger.html), this module is for nothrow and @nogc env. Unlike [dplug.core.nogc.debugLogf](https://github.com/AuburnSounds/Dplug/blob/f635a48fa09c3ffe20d38f3d8c605fd5642ee293/core/dplug/core/nogc.d#L370), this supports `{severity}{MMDD HH:MM:SS.microseconds} {thread id} {file:line}]` prefix like tensorflow.

```
$ dub test

Running kdr-test-library 
I1225 16:30:47.651584 140065791961536 source/kdr/logging.d:86] 0-th log from this thread 140065791961536.
I1225 16:30:47.651588 140065790907968 source/kdr/logging.d:81] 0-th log from other thread 140065790907968.
I1225 16:30:47.751709 140065791961536 source/kdr/logging.d:86] 1-th log from this thread 140065791961536.
I1225 16:30:47.751818 140065790907968 source/kdr/logging.d:81] 1-th log from other thread 140065790907968.
I1225 16:30:47.851909 140065791961536 source/kdr/logging.d:86] 2-th log from this thread 140065791961536.
I1225 16:30:47.851988 140065790907968 source/kdr/logging.d:81] 2-th log from other thread 140065790907968.
benchmark synth2/default: 19 ms 785 us
13 modules passed unittests
```